### PR TITLE
Fix #22. Add new tests for token assesment. Throw new error when no tokens are discovered.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,7 @@
             matches,
             len,
             i,
-            p,
-            hasTokens = false;
+            p;
 
         // default locale to null
         /*jshint expr:true */
@@ -108,19 +107,12 @@
                 // create an object for the token when found
                 matches = chunks[i].match(REGEX_TOKEN_AND_FORMATTER);
                 if (matches) {
-                    hasTokens = true;
-
                     chunks[i] = {
                         // the valuename is the "key" for the token ... ${key}
                         valueName: matches[1],
                         formatter: matches[2],
                     };
                 }
-            }
-
-            // No tokens
-            if (hasTokens !== true) {
-                throw new RangeError('No tokens were provided.');
             }
 
             // our pattern should now be the chunked array

--- a/tests/index.js
+++ b/tests/index.js
@@ -214,15 +214,13 @@ describe('IntlMessageFormat', function () {
     describe('using a string pattern', function () {
 
         it('should fail if there is no argument in the string', function () {
-            try {
-                var msgFmt = new IntlMessageFormat('My name is {FIRST LAST}');
+            var msgFmt = new IntlMessageFormat('My name is {FIRST LAST}'),
+                m = msgFmt.format({
+                        FIRST: 'Anthony',
+                        LAST: 'Pipkin'
+                    });
 
-                // should never reach here
-                expect(false, 'IntlMessageFormat should have thrown').to.equal(true);
-            } catch (e) {
-                var err = new RangeError('No tokens were provided.');
-                expect(err.toString()).to.equal(e.toString());
-            }
+            expect(m).to.equal('My name is {FIRST LAST}');
         });
 
         it('should properly replace direct arguments in the string', function () {
@@ -720,13 +718,13 @@ describe('IntlMessageFormat', function () {
                 state = 'Missouri',
                 m;
 
-            it('should fail as no tokens are discovered in the string', function () {
-                try {
-                    msg = new IntlMessageFormat("{ST ATE}");
-                    m = msg.format();
-                } catch (e) {
-                    expect(e.toString()).to.equal(rangeErr.toString());
-                }
+            it('should return the same string as no tokens are discovered', function () {
+                msg = new IntlMessageFormat("{ST ATE}");
+                m = msg.format({
+                    "ST ATE": state
+                });
+
+                expect(m).to.equal('{ST ATE}');
             });
         });
 


### PR DESCRIPTION
Address missed tokens and tokens with extra characters from Issue #22
