### PR TITLE
Replace xunit-file with reporter-file

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-uglify": "~0.2.7",
     "istanbul": "~0.1.46",
     "mocha": "~1.15.1",
-    "reporter-file": "git://github.com/apipkin/reporter-file.git#master",
+    "reporter-file": "~0.0.1",
     "mockery": "~1.4.0",
     "intl": "~0.1.0"
   },


### PR DESCRIPTION
After much frustration with xunit-file reporting I decided to take a look at it and add some colors. Then I noticed that the config file turns off false reporting to the console. I also noticed that it was impossible to get a different console report, but Mocha had so many that were awesome. 

So I struck out to create a reporter that would write to an xml file and allow you to use any reported you wanted. I ended up with https://github.com/apipkin/reporter-file It works amazingly and writes proper XML data with `js2xmlparser` (though I do have a pull request over there https://github.com/michaelkourlas/node-js2xmlparser/pull/6 to wrap in CDATA instead of escaping) 

Anyways, this defaults to Spec for console reporting, while still generating the XML file xunit-file was generating. It can be overwritten by setting an environment variable as MOCHA_REPORTER
