### PR TITLE
bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intl-messageformat",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "implementation of the ECMA 402 proposal for MessageFormat",
   "keywords": [
     "intl",


### PR DESCRIPTION
Updated the version number since the code changed (somewhat significantly). I think this is required since NPM will cache the version of the module based on the version number (even for git URL dependencies such as found in dust-helper-intl package).
