### PR TITLE
moving clrl pkg into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,7 @@
     "mockery": "~1.4.0",
     "xunit-file": "*",
     "yeti": "~0.2.25",
-    "benchmark": "~1.0.0"
-  },
-  "optionalDependencies": {
+    "benchmark": "~1.0.0",
     "cldr": "~2.0.1"
   },
   "scripts": {


### PR DESCRIPTION
`cldr` depends on `libxmljs`, which use native `.node` files, which will not work in SD/ynpm. Apparently, the `optionalDependencies` will fail silent only if the module itself fails, but not when some of the dependencies fails.

Anyhow, since the `cldr` is only used when in development, we can simply move `cldr` to the `devDependencies` and flight with it.
