### PR TITLE
Update index.js to use O.dP for "default"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
+'use strict';
+
 var m = require('./lib/full.js');
 
-// providing an idiomatic api for the nodejs version of this module
-module.exports = exports = m.default;
-// preserving the original api in case another module is relying on that
-exports.default = m.default;
+// Provide an idiomatic API for the Node.js version of this package.
+exports = module.exports = m.default;
+// Preserve the original API in case another package relies on `default`.
+Object.defineProperty(exports, 'default', {value: m.default});


### PR DESCRIPTION
This makes the `.default` export in the Node.js package non-enumerable.

/cc @caridy
