### PR TITLE
Greatly improve perf of `format()`

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -75,15 +75,16 @@ Compiler.prototype.compileMessageText = function (element) {
 };
 
 Compiler.prototype.compileArgument = function (element) {
-    var format   = element.format,
-        formats  = this.formats,
-        locales  = this.locales,
-        pluralFn = this.pluralFn,
-        options;
+    var format = element.format;
 
     if (!format) {
         return new StringFormat(element.id);
     }
+
+    var formats  = this.formats,
+        locales  = this.locales,
+        pluralFn = this.pluralFn,
+        options;
 
     switch (format.type) {
         case 'numberFormat':

--- a/src/es5.js
+++ b/src/es5.js
@@ -8,7 +8,7 @@ See the accompanying LICENSE file for terms.
 
 import {hop} from './utils';
 
-export {defineProperty, objCreate, fnBind};
+export {defineProperty, objCreate};
 
 // Purposely using the same implementation as the Intl.js `Intl` polyfill.
 // Copyright 2013 Andy Earnshaw, MIT License
@@ -44,13 +44,4 @@ var objCreate = Object.create || function (proto, props) {
     }
 
     return obj;
-};
-
-var fnBind = Function.prototype.bind || function (thisObj) {
-    var fn   = this,
-        args = [].slice.call(arguments, 1);
-
-    return function () {
-        fn.apply(thisObj, args.concat([].slice.call(arguments)));
-    };
 };


### PR DESCRIPTION
This greatly improves the perf of calling `format()` on an IntlMessageFormat instance by not using function `bind()`. Performance increases are ~50% for complex messages, and ~10x for simple messages!

**Before:**

```
Running "benchmark:format" (benchmark) task

Running benchmark format_cached_complex_msg [tests/benchmark/format_cached_complex_msg.js]...
>> format_cached_complex_msg x 30,594 ops/sec ±10.22% (66 runs sampled)

Running benchmark format_cached_string_msg [tests/benchmark/format_cached_string_msg.js]...
>> format_cached_string_msg x 3,199,929 ops/sec ±8.50% (59 runs sampled)
```

**After:**

```
Running "benchmark:format" (benchmark) task

Running benchmark format_cached_complex_msg [tests/benchmark/format_cached_complex_msg.js]...
>> format_cached_complex_msg x 48,246 ops/sec ±0.23% (94 runs sampled)

Running benchmark format_cached_string_msg [tests/benchmark/format_cached_string_msg.js]...
>> format_cached_string_msg x 28,247,906 ops/sec ±0.76% (100 runs sampled)
```

---

**A new build should be committed after this is merged.**
