### PR TITLE
Remove use of `indexOf()` when adding locale data

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -242,7 +242,7 @@ MessageFormat.prototype._resolveLocale = function (locales) {
         }
 
         // Return the first locale for which we have CLDR data registered.
-        if (locale in localeData) {
+        if (hop.call(localeData, locale)) {
             return locale;
         }
     }


### PR DESCRIPTION
`Array.prototype.indexOf()` is an ES5 method we were using when it wasn't necessary. This remove its usage, and improves the error handling when adding locale data and resolve locales.

Fixes #76
