### PR TITLE
throw at compile time if case `other` was not found (see

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -110,12 +110,18 @@ Compiler.prototype.compileArgument = function (element) {
 
         case 'pluralFormat':
             options = this.compileOptions(element);
+            if (!options['other']) {
+                throw new Error('`other` case was not provided in plural rule');
+            }
             return new PluralFormat(
                 element.id, format.ordinal, format.offset, options, pluralFn
             );
 
         case 'selectFormat':
             options = this.compileOptions(element);
+            if (!options['other']) {
+                throw new Error('`other` case was not provided in plural rule');
+            }
             return new SelectFormat(element.id, options);
 
         default:

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -120,7 +120,7 @@ Compiler.prototype.compileArgument = function (element) {
         case 'selectFormat':
             options = this.compileOptions(element);
             if (!options['other']) {
-                throw new Error('`other` case was not provided in plural rule');
+                throw new Error('`other` case was not provided in select rule');
             }
             return new SelectFormat(element.id, options);
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -378,4 +378,20 @@ describe('IntlMessageFormat', function () {
             expect(ptMZ.format({num: 0})).to.equal('other');
         });
     });
+
+    describe('at compile time', function () {
+        it('should fail if no `other` case was provided for plural, select and selectordinal rules', function () {
+            var messages = [
+                '{NUMBER, plural, =1 {One}}',
+                '{GENDER, plural, male {#}}',
+                '{YEAR, selectordinal, one {#st}}'
+            ];
+            function compileMessage() { return new IntlMessageFormat(msg); }
+            function expectError(e) { expect(e).to.be.an(Error); };
+
+            expect(compileMessage).withArgs(messages[0]).to.throwException(expectError);
+            expect(compileMessage).withArgs(messages[1]).to.throwException(expectError);
+            expect(compileMessage).withArgs(messages[2]).to.throwException(expectError);
+        });
+    })
 });


### PR DESCRIPTION
https://github.com/yahoo/intl-messageformat/issues/129)
