### PR TITLE
Make `locales` argument optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare class IntlMessageFormat {
-    constructor(message: string, locales: string | string[], formats?: any);
+    constructor(message: string, locales?: string | string[], formats?: any);
     format(context?: any): string;
     static defaultLocale: string;
 }


### PR DESCRIPTION
[Docs](https://github.com/yahoo/intl-messageformat#intlmessageformat-constructor) state that `If you do not provide a locale, the default locale will be used.`, and it does actually work but complains with a type error.